### PR TITLE
Compatibility with pixel-scroll-precision-mode

### DIFF
--- a/ultra-scroll.el
+++ b/ultra-scroll.el
@@ -315,7 +315,7 @@ on systems providing pixel-level scroll data; see
 your system and hardware provide."
   :global t
   :group 'scrolling
-  :keymap pixel-scroll-precision-mode-map ; reuse
+  (pixel-scroll-precision-mode (if ultra-scroll-mode 1 -1)) ;; reuse
   (cond
    (ultra-scroll-mode
     (unless (> scroll-conservatively 0)
@@ -331,8 +331,7 @@ your system and hardware provide."
    (t
     (define-key pixel-scroll-precision-mode-map [remap pixel-scroll-precision] nil)
     (setq pixel-scroll-precision-use-momentum
-	  (get 'pixel-scroll-precision-use-momentum 'us-orig-value))))
-  (setq mwheel-coalesce-scroll-events (not ultra-scroll-mode)))
+	  (get 'pixel-scroll-precision-use-momentum 'us-orig-value)))))
 
 (provide 'ultra-scroll)
 ;;; ultra-scroll.el ends here


### PR DESCRIPTION
My osm.el and vertico-mouse.el packages set pixel-scroll-precision-mode locally to nil such that the minor mode keymap is disabled. This is certainly a hack since these packages are not yet directly compatible with pixel-scroll-precision-mode.

Since you already reuse the pixel-scroll-precision-mode-map in ultra-scroll-mode, I suggest to reuse pixel-scroll-precision-mode completely and enable it as long as ultra-scroll-mode is enabled, which also ensures that the pixel-scroll-precision-mode-map is reused. This way, the aforementioned trick of setting pixel-scroll-precision-mode locally to nil in certain modes will continue to work.

I hope that ultra-scroll-mode and pixel-scroll-precision-mode can move closer together in the future and I hope that you upstream the relevant bits. It seems there is huge interest in more efficient scrolling.