### PR TITLE
Track scroll-conservatively per-buffer to avoid clobbering local values

### DIFF
--- a/ultra-scroll.el
+++ b/ultra-scroll.el
@@ -217,14 +217,18 @@ actions."
 
 ;;;; Other scroll begin/end config actions
 (defvar ultra-scroll--gc-percentage-orig nil)
-(defvar ultra-scroll--scroll-conservatively-orig nil)
+;; Buffer-local: `scroll-conservatively' can be set buffer-locally (e.g. some
+;; terminal modes pin it >=100), so the saved value must be tracked per-buffer.
+;; nil means "this buffer's value was not raised", so do not restore.
+(defvar-local ultra-scroll--scroll-conservatively-orig nil)
 (defvar ultra-scroll--timer nil)
 (defun ultra-scroll--end-scroll ()
   "Reset GC variable and scroll settings during idle time."
   (when ultra-scroll--gc-percentage-orig
     (setq gc-cons-percentage ultra-scroll--gc-percentage-orig))
-  (when (< ultra-scroll--scroll-conservatively-orig 100)
-    (setq scroll-conservatively ultra-scroll--scroll-conservatively-orig))
+  (when ultra-scroll--scroll-conservatively-orig
+    (setq scroll-conservatively ultra-scroll--scroll-conservatively-orig
+	  ultra-scroll--scroll-conservatively-orig nil))
   (setq ultra-scroll--timer nil))
 
 (defsubst ultra-scroll--prepare-to-scroll (&optional window)
@@ -542,8 +546,9 @@ your system and hardware provide."
     ;; don't need to do so for scrolling, but a bug in half-visible
     ;; cursors lead to 150-400x slowdown in redisplay; see #32.
     (setq-default make-cursor-line-fully-visible nil)
-    (setq ultra-scroll--gc-percentage-orig gc-cons-percentage
-	  ultra-scroll--scroll-conservatively-orig scroll-conservatively))
+    ;; `ultra-scroll--scroll-conservatively-orig' is saved per-buffer at scroll
+    ;; start (see `ultra-scroll--prepare-to-scroll'); nothing to seed here.
+    (setq ultra-scroll--gc-percentage-orig gc-cons-percentage))
    (t
     (define-key pixel-scroll-precision-mode-map [remap pixel-scroll-precision] nil)
     (setq pixel-scroll-precision-use-momentum


### PR DESCRIPTION
ultra-scroll raises `scroll-conservatively` to 101 during a scroll and restores the prior value on idle, tracking the saved value in a global variable (`ultra-scroll--scroll-conservatively-orig`).

`scroll-conservatively` can be set buffer-locally, and some modes set it to >=100 on purpose. Tracking the saved value globally leaks it across buffers:

1. Scroll in a buffer where `scroll-conservatively` is <100 (e.g. the global default). `--prepare-to-scroll` saves that low value and raises to 101.
2. Scroll in a buffer whose buffer-local `scroll-conservatively` is >=100. `--prepare-to-scroll` skips the save (nothing to raise), but `--end-scroll` still runs the restore and writes the stale low value into this buffer, overwriting its buffer-local >=100 setting.

Once lowered, a forced redisplay while point is off-screen makes Emacs recenter, yanking the window by a large amount.

I hit this with the ghostel terminal emulator, which sets `scroll-conservatively` to 101 buffer-locally so its decoupled point does not trigger a recenter. After scrolling a normal buffer and then the terminal, the terminal's value was reset to the global default, and the next redraw (a spinner timer) jumped the window several pages toward the top.

### Fix

Make `ultra-scroll--scroll-conservatively-orig` buffer-local and use nil to mean "not raised in this buffer", so `--end-scroll` only restores when this buffer's value was actually raised. The save in `--prepare-to-scroll` already only runs when the value is <100, so it doubles as the sentinel. The seed in the mode-enable body is no longer needed and is removed.

### Testing

- Byte-compiles with no new warnings.
- In `emacs -Q`: a <100 buffer is raised to 101 during scroll and restored after; a >=100 buffer is left untouched with no nil-comparison error; a >=100 buffer is not affected by a prior scroll in a <100 buffer.